### PR TITLE
Add from-RNG helper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 
 [dependencies]
 libm = "0.2.7"
+rand_core_0_6 = { package = "rand_core", version = "0.6" }
 
 [dev-dependencies]
 rand = { version = "0.8.5", features = [ "std", "std_rng" ] }


### PR DESCRIPTION
The helper produces bits from a &mut Rng, only buffering 32bit at a time. This is useful to test RNGs on systems that can't easily allocate 1MiBit of random data -- essentially it's a copy-out of what I did for my RIOT OS test routine.

The downside, API-wise, is that the crate that used not to have any foreign-crate API surface now. But we're not aiming for a 1.0 here...